### PR TITLE
Now handles login errors

### DIFF
--- a/sfs
+++ b/sfs
@@ -14,7 +14,7 @@ Options:
 """
 from docopt import docopt
 import os, getpass, sys
-from snapchat_core import constants
+from snapchat_core import constants, SfsSession
 from snapchat_fs import *
 
 __author__ = "Alex Clemmer, Chad Brubaker"
@@ -62,10 +62,15 @@ def initialize_user():
     print "Please enter your password (NOTE: STORED IN PLAINTEXT):"
     password = getpass.getpass('')
 
+    # Try logging in first before we continue
+    ss = SfsSession(username, password)
+    ss.login()
+
     # write username/password to file
     with open(constants.CONFIG_FILE_PATH, 'w') as w:
         w.write("USERNAME=%s\n" % username)
         w.write("PASSWORD=%s\n" % password)
+
 
 def init_settings_from_config_file():
     """
@@ -78,6 +83,7 @@ def init_settings_from_config_file():
     """
     # create config file with username/password if it doesn't exist
     if not os.path.exists(constants.CONFIG_FILE_PATH):
+        # can fail and raise a login exception, caught by main()
         initialize_user()
 
     # open config file, populate settings dictionary with fields we find
@@ -130,9 +136,13 @@ def cli(arguments):
 
 def main():
     global SETTINGS
-    init_settings_from_config_file()
-    arguments = docopt(__doc__, version=constants.VERSION)
-    cli(arguments)
+    try:
+        init_settings_from_config_file()
+        arguments = docopt(__doc__, version=constants.VERSION)
+        cli(arguments)
+    except Exception as e:
+        print e
+        exit()
 
 if __name__ == '__main__':
     main()

--- a/snapchat_core/api.py
+++ b/snapchat_core/api.py
@@ -80,6 +80,10 @@ class SnapchatSession():
         result = SnapchatSession._post_or_fail(constants.LOGIN_RESOURCE
                                     , req_params).json()
 
+        # make sure login was successful
+        if result['logged'] == False:
+            raise Exception("Login failed, invalid credentials")
+
         # update session state with login response information
         self.session_token = result[AUTH_TOKEN]
         self.login_data = result

--- a/snapchat_core/api.py
+++ b/snapchat_core/api.py
@@ -89,12 +89,16 @@ class SnapchatSession():
         self.login_data = result
         self._update_session_state(result)
 
-    def upload_image(self, image_data, media_id):
+    def upload_image(self, filename, media_id):
         """
         Uploads an image to Snapchat.
         @filename Name of the image to upload.
         @media_id The ID to give the image we upload.
         """
+
+        with open(filename) as f:
+            image_data = f.read()
+
         # generate request parameters
         encrypted_data = SnapchatSession._snapchat_basic_encrypt(
             image_data)


### PR DESCRIPTION
If you try to set this up with an invalid login, it'll error out and quit without saving credentials to the file so you can try again by simply entering the command again.

The initial login only runs once per installation.

Every other time the user's login fails, they are expected to manually change their credentials in the file (it's a lot harder to remove values from a file than it is to add them).
