### PR TITLE
Add requirements.txt for all dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ To add more to this config file, all you need to do is follow that format. Curre
 
 The `sfs` file is a Python script that currently sits in the root directory and never moves, because there's no installation script. You can run it with a command like `./sfs`. If you want to move into `bin/` or something, you'll have to do it yourself.
 
+In order to install dependencies: ``pip install -r requirements.txt``
+
 Someday this will be `pip`-installable or something.
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+docopt>=0.6.1
+pyasn1>=0.1.7
+pycrypto>=2.6.1
+requests>=2.1.0
+rsa>=3.1.2


### PR DESCRIPTION
I added a `requirements.txt` file in case a user does not have all the necessary python modules installed. To verify this covers all dependencies, I ran it under a clean environment using virtualenv and exported all installed modules:

```
$: virtualenv env
$: source env/bin/activate
$: pip install docopt
$: pip install pycrypto
$: pip install requests
$: pip freeze > requirements.txt
```

Now `pip install -r requirements.txt` takes care of all dependencies.
